### PR TITLE
remove ABIEncoderV2 cruft

### DIFF
--- a/earlybird-mock-app/src/RukhVersion/MockApp.sol
+++ b/earlybird-mock-app/src/RukhVersion/MockApp.sol
@@ -1,7 +1,6 @@
 // src/RukhVersion/MockApp.sol
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
-pragma experimental ABIEncoderV2;
 
 import "../../utils/TestToken.sol";
 import "earlybird/src/IReceiver/IReceiver.sol";

--- a/earlybird-mock-app/src/RukhVersion/RecsContract.sol
+++ b/earlybird-mock-app/src/RukhVersion/RecsContract.sol
@@ -1,7 +1,6 @@
 // src/RukhVersion/RecsContract.sol
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
-pragma experimental ABIEncoderV2;
 
 contract RecsContract {
     // Address of default receive relayer 1

--- a/earlybird-ping-pong-app/src/FeeCollector.sol
+++ b/earlybird-ping-pong-app/src/FeeCollector.sol
@@ -1,7 +1,6 @@
 // src/FeeCollector.sol
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
-pragma experimental ABIEncoderV2;
 
 import "earlybird/src/FeeCollector/IFeeCollector.sol";
 import "openzeppelin-contracts/token/ERC20/ERC20.sol";

--- a/earlybird-ping-pong-app/src/RukhVersion/PingPong.sol
+++ b/earlybird-ping-pong-app/src/RukhVersion/PingPong.sol
@@ -1,7 +1,6 @@
 // src/RukhVersion/PingPong.sol
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
-pragma experimental ABIEncoderV2;
 
 // Note: Contracts needs to be funded with token being used for message payment.abi
 

--- a/earlybird-ping-pong-app/src/ThunderbirdVersion/PingPong.sol
+++ b/earlybird-ping-pong-app/src/ThunderbirdVersion/PingPong.sol
@@ -1,7 +1,6 @@
 // src/ThunderbirdVersion/PingPong.sol
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
-pragma experimental ABIEncoderV2;
 
 // Note: Contracts needs to be funded with token being used for message payment.abi
 

--- a/fee-collectors/src/FeeCollector.sol
+++ b/fee-collectors/src/FeeCollector.sol
@@ -1,7 +1,6 @@
 // src/SendingOracle.sol
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
-pragma experimental ABIEncoderV2;
 
 import "../lib/earlybird-evm-interfaces/src/FeeCollector/IFeeCollector.sol";
 


### PR DESCRIPTION
ABIEncoderV2 is enabled by default since 0.8.0